### PR TITLE
Add functional testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+clouds.yaml

--- a/tests/functional/README.md
+++ b/tests/functional/README.md
@@ -1,0 +1,9 @@
+# Functional test scripts
+
+Tests are divided into whether they require a lessee id specification or not. When testing, both `test-lessee-id.sh` and `test-no-lessee-id.sh` should be run.
+
+The tests expect the following project structure: a project called `test1`, with 2 subprojects, called `test1-subproject` and `test1-subproject-1`.
+
+Currently, the uuid of `test1` is included as a variable called `project_id` at the top of the test scripts, since it is needed to create the dummy node. After making a project called `test1`, that uuid should be changed.
+
+The project authentication info should be included in `clouds.yaml`, so the project for a command can be specified with `--os-cloud` in the scripts.

--- a/tests/functional/cleanup.sh
+++ b/tests/functional/cleanup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+test_offer_uuid=$1
+
+#######################
+## OFFER DELETE TEST ##
+#######################
+
+# Tests that an owner can delete an offer on a node they own
+
+echo "OFFER DELETE TEST"
+echo "Deleting offer $test_offer_uuid"
+openstack --os-cloud test1 esi offer delete $test_offer_uuid && echo "OFFER DELETE TEST SUCCEEDED"

--- a/tests/functional/setup.sh
+++ b/tests/functional/setup.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+tmpfile=$1
+project_id=$2
+start=$3
+end=$4
+lessee_option=''
+nodefile=$(mktemp /tmp/nodes/XXXX)
+errfile=$(mktemp ./errXXXXXX)
+node_uuid=$(echo $nodefile | sed 's/\/tmp\/nodes\///')
+
+# Create dummy node
+
+cat <<EOF > /tmp/nodes/$node_uuid
+{
+    "project_owner_id": "$project_id",
+    "server_config": {
+        "new attribute XYZ": "This is just a sample list of free-form attributes used for describing a server.",
+        "cpu_type": "Intel Xeon",
+        "cores": 16,
+        "ram_gb": 512,
+        "storage_type": "samsung SSD",
+        "storage_size_gb": 204
+    }
+}
+EOF
+
+# Check if the lessee was passed
+if ! [[ -z ${5+x} ]]; then
+  lessee_option=" --lessee $5"
+fi
+
+#######################
+## OFFER CREATE TEST ##
+#######################
+
+# Tests that an owner can create an offer on a node they own
+
+echo "OFFER CREATE TEST"
+
+openstack --os-cloud test1 esi offer create \
+  $node_uuid \
+  --start-time $start \
+  --end-time $end \
+  --resource-type dummy_node\
+  $lessee_option \
+  -f shell > $tmpfile \
+  || { ec=$?; echo "ERROR: failed to create offer" >&2; exit $ec; }
+
+cat $tmpfile
+echo "OFFER CREATE TEST SUCCEEDED"
+
+. $tmpfile
+
+cat <<EOF
+Created offer $uuid:
+  Starting at: $start_time
+  Ending at:   $end_time
+  For: $resource_type $node_uuid
+EOF
+
+cat <<EOF >> $tmpfile
+errfile=$errfile
+nodefile=$nodefile
+node_uuid=$node_uuid
+EOF

--- a/tests/functional/test-lessee-id.sh
+++ b/tests/functional/test-lessee-id.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+
+project_id=75681640118a4890b3da0d106eae8af7 # test1 uuid
+tmpfile=$(mktemp ./leaseXXXXXX)
+start=$(date +%Y-%m-%d)
+end=$(date -d "+5 days" +%Y-%m-%d)
+lessee='test1-subproject'
+
+# Setup script, contains offer create test
+
+./setup.sh $tmpfile $project_id $start $end $lessee
+
+cat $tmpfile
+# Sources variables defined in the setup script
+. $tmpfile
+
+# The uuid variable will be overwritten, so we save it here
+test_offer_uuid=$uuid
+# Run cleanup if the script exits, contains offer delete test
+trap "./cleanup.sh $test_offer_uuid; rm -f $tmpfile $errfile $nodefile" EXIT 
+
+#####################
+## OFFER LIST TEST ##
+#####################
+
+# Tests that a lessee can list offers
+
+echo "OFFER LIST TEST"
+
+openstack --os-cloud test1-subproject esi offer list -f json > $tmpfile \
+  || { ec=$?; echo "ERROR: failed to list offers" >&2; exit $ec; }
+jq -r ".[].UUID" $tmpfile | grep $uuid \
+  || { ec=$?; echo "ERROR: test offer not visible" >&2; exit $ec; }
+
+echo "OFFER LIST TEST SUCCEEDED"
+
+###################################
+## OFFER CLAIM INVALID USER TEST ##
+###################################
+
+# Tests that a lessee cannot create a claim on an offer that they don't have access to
+
+echo "OFFER CLAIM INVALID USER TEST"
+
+openstack --os-cloud test1-subproject-1 esi offer claim $test_offer_uuid -f shell > $tmpfile 2> $errfile
+ec=$?
+expected_error='esi_leap:offer:offer_admin is disallowed by policy'
+
+if ! grep -q "$expected_error" $errfile; then
+  if [[ $ec -eq 0 ]]; then
+    echo "ERROR: succeeded claiming offer despite invalid user" >&2
+  else
+    echo "ERROR: unexpected error during invalid user test" >&2
+    cat $errfile >&2
+  fi
+  exit 1
+fi
+
+echo "OFFER CLAIM INVALID USER TEST SUCCEEDED"
+
+######################
+## OFFER CLAIM TEST ##
+######################
+
+# Tests that a lessee can claim an offer available to them
+
+echo "OFFER CLAIM TEST"
+
+openstack --os-cloud test1-subproject esi offer claim $uuid -f shell > $tmpfile \
+  || { ec=$?; echo "ERROR: failed to claim offer" >&2; exit $ec; }
+
+echo "OFFER CLAIM TEST SUCCEEDED"
+
+# Print info about the newly created lease
+
+. $tmpfile
+
+cat <<EOF
+Created lease $uuid:
+  Starting at: $start_time
+  Ending at:   $end_time
+  For: $resource_type $resource_uuid
+  From offer:  $test_offer_uuid
+EOF
+
+#####################
+## LEASE LIST TEST ##
+#####################
+
+# Tests that an owner can view leases on nodes they own
+
+echo "LEASE LIST TEST"
+
+openstack --os-cloud test1 esi lease list -f json > $tmpfile \
+  || { ec=$?; echo "ERROR: failed to list leases" >&2; exit $ec; }
+
+jq -r ".[].UUID" $tmpfile | grep $uuid \
+  || { ec=$?; echo "ERROR: test lease not visible" >&2; exit $ec; }
+
+echo "LEASE LIST TEST SUCCEEDED"
+
+#######################
+## LEASE DELETE TEST ##
+#######################
+
+# Tests that an owner can delete a lease on a node they own
+
+echo "LEASE DELETE TEST"
+
+openstack  --os-cloud test1 esi lease delete $uuid \
+  || { ec=$?; echo "ERROR: failed to delete lease" >&2; exit $ec; }
+
+echo "LEASE DELETE TEST SUCCEEDED"

--- a/tests/functional/test-no-lessee-id.sh
+++ b/tests/functional/test-no-lessee-id.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+
+project_id=75681640118a4890b3da0d106eae8af7 # test1 uuid
+tmpfile=$(mktemp ./leaseXXXXXX)
+start=$(date +%Y-%m-%d)
+end=$(date -d "+5 days" +%Y-%m-%d)
+
+# Setup script, contains offer create test
+
+./setup.sh $tmpfile $project_id $start $end $resource_type
+
+. $tmpfile
+
+# The uuid variable will be overwritten, so we save it here
+test_offer_uuid=$uuid
+# Run cleanup if the script exits, contains offer delete test
+trap "./cleanup.sh $test_offer_uuid; rm -f $tmpfile $errfile $nodefile" EXIT
+
+#####################################
+## OFFER CREATE TIME CONFLICT TEST ##
+#####################################
+
+# Tests that an owner cannot create an offer on a node that would cause a time conflict
+
+echo "OFFER CREATE TIME CONFLICT TEST"
+
+openstack --os-cloud test1 esi offer create \
+  $node_uuid \
+  --start-time $start \
+  --end-time $end \
+  --resource-type $resource_type \
+  -f shell > $tmpfile 2> $errfile
+ec=$?
+expected_error="Time conflict for dummy_node $node_uuid."
+
+if ! cat $errfile | grep -q "$expected_error"; then
+  if [[ $ec -eq 0 ]]; then
+    echo "ERROR: succeeded creating offer despite time conflict" >&2
+    . $tmpfile
+    echo "Deleting time conflict test offer..."
+    ./cleanup.sh $uuid
+  else
+    echo "ERROR: unexpected error during time conflict test" >&2
+    cat $errfile >&2
+  fi
+  exit 1
+fi
+
+echo "OFFER CREATE TIME CONFLICT TEST SUCCEEDED"
+
+#################################
+## OFFER DELETE NOT FOUND TEST ##
+#################################
+
+# Tests that an owner cannot delete a nonexistent offer
+
+echo "OFFER DELETE NOT FOUND TEST"
+
+openstack --os-cloud test1 esi offer delete "notanofferuuid" > $tmpfile 2> $errfile
+ec=$?
+expected_error='Offer with name or uuid notanofferuuid not found.'
+if ! grep -q "$expected_error" $errfile; then
+  if [[ $ec -eq 0 ]]; then
+    echo "ERROR: succeeded deleting offer that shouldn't exist. Either someone named their offer 'notanofferuuid' or the delete command gave a success when it shouldn't have" >&2
+  else
+    echo "ERROR: unexpected error during offer not found test" >&2
+    cat $errfile >&2
+  fi
+  exit 1
+fi
+
+echo "OFFER DELETE NOT FOUND TEST SUCCEEDED"
+
+############################################
+## OFFER NOT AVAILABLE IN TIME RANGE TEST ##
+############################################
+
+# Tests that a lessee cannot claim an offer for a time range it is not available for
+
+echo "OFFER NOT AVAILABLE IN TIME RANGE TEST"
+
+openstack --os-cloud test1-subproject esi offer claim $test_offer_uuid --start-time $(date -d "+6 days" +%Y-%m-%d) --end-time $(date -d "+7 days" +%Y-%m-%d) -f shell > $tmpfile 2> $errfile
+ec=$?
+expected_error="Offer $test_offer_uuid has no availabilities at given time range"
+
+if ! grep -q "$expected_error" $errfile; then
+  if [[ $ec -eq 0 ]]; then
+    echo "ERROR: offer was successfully claimed during invalid time range" >&2
+  else
+    echo "ERROR: unexpected error during not available in time range test" >&2
+    cat $errfile >&2
+  fi
+  exit 1
+fi
+
+echo "OFFER NOT AVAILABLE IN TIME RANGE TEST SUCCEEDED"
+
+######################
+## OFFER CLAIM TEST ##
+######################
+
+# Tests that a lessee can claim an offer available to them
+# Setting up a claim is needed for the claim time conflict test
+
+echo "OFFER CLAIM TEST"
+
+openstack --os-cloud test1-subproject esi offer claim $test_offer_uuid -f shell > $tmpfile \
+  || { ec=$?; echo "ERROR: failed to claim offer" >&2; exit $ec; }
+cat $tmpfile
+. $tmpfile
+
+echo "OFFER CLAIM TEST SUCCEEDED"
+
+####################################
+## OFFER CLAIM TIME CONFLICT TEST ##
+####################################
+
+# Tests that a lessee cannot create a claim on an offer that would cause a time
+# conflict with a lease created by another lessee
+
+echo "OFFER CLAIM TIME CONFLICT TEST"
+
+openstack --os-cloud test1-subproject-1 esi offer claim $test_offer_uuid -f shell > $tmpfile 2> $errfile
+ec=$?
+expected_error='Attempted to create lease resource with an invalid Start Time.*'
+cat $errfile
+
+if ! grep -q "$expected_error" $errfile; then
+  if [[ $ec -eq 0 ]]; then
+    echo "ERROR: succeeded claiming offer despite time conflict" >&2
+  else
+    echo "ERROR: unexpected error during time conflict test" >&2
+    cat $errfile >&2
+  fi
+  exit 1
+fi
+
+echo "OFFER CLAIM TIME CONFLICT TEST SUCCEEDED"


### PR DESCRIPTION
I have a basic test script which tests the following actions: offer creation, offer listing, offer claiming, lease listing, lease deletion, and offer deletion. I'm not sure how I should set up error handling, or how I should organize the tests into different scripts. Most tests will rely on offer creation and deletion working at least, so if I make multiple scripts, those would probably need to be in all of them.