### PR TITLE
Fixes to broken functional tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 clouds.yaml
+tests/functional/err*

--- a/tests/functional/setup.sh
+++ b/tests/functional/setup.sh
@@ -4,10 +4,15 @@ tmpfile="$1"
 project_id="$2"
 start="$3"
 end="$4"
+resource_type="$5"
 lessee_option=''
 nodefile=$(mktemp /tmp/nodes/XXXX)
 errfile=$(mktemp ./errXXXXXX)
 node_uuid=$(echo $nodefile | sed 's/\/tmp\/nodes\///')
+
+if [[ -z "$5" ]]; then
+    resource_type="dummy_node"
+fi
 
 # Create dummy node
 
@@ -26,8 +31,8 @@ cat <<EOF > /tmp/nodes/$node_uuid
 EOF
 
 # Check if the lessee was passed
-if ! [[ -z "$5" ]]; then
-  lessee_option=" --lessee $5"
+if ! [[ -z "$6" ]]; then
+  lessee_option=" --lessee $6"
 fi
 
 #######################
@@ -42,7 +47,7 @@ openstack --os-cloud test1 esi offer create \
   $node_uuid \
   --start-time "$start" \
   --end-time "$end" \
-  --resource-type dummy_node\
+  --resource-type "$resource_type"\
   $lessee_option \
   -f shell > $tmpfile \
   || { ec=$?; echo "ERROR: failed to create offer" >&2; exit $ec; }

--- a/tests/functional/test-lease-expire.sh
+++ b/tests/functional/test-lease-expire.sh
@@ -4,6 +4,7 @@ project_id=75681640118a4890b3da0d106eae8af7 # test1 uuid
 tmpfile=$(mktemp ./leaseXXXXXX)
 start=$(date +%Y-%m-%d)
 end=$(date -d "+5 days" +"%Y-%m-%d")
+resource_type="dummy_node"
 
 # Setup script, contains offer create test
 

--- a/tests/functional/test-lessee-id.sh
+++ b/tests/functional/test-lessee-id.sh
@@ -43,7 +43,7 @@ echo "OFFER CLAIM INVALID USER TEST"
 
 openstack --os-cloud test1-subproject-1 esi offer claim $test_offer_uuid -f shell > $tmpfile 2> $errfile
 ec=$?
-expected_error='esi_leap:offer:offer_admin is disallowed by policy'
+expected_error="Access was denied to offer $test_offer_uuid."
 
 if ! grep -q "$expected_error" $errfile; then
   if [[ $ec -eq 0 ]]; then

--- a/tests/functional/test-lessee-id.sh
+++ b/tests/functional/test-lessee-id.sh
@@ -4,11 +4,12 @@ project_id=75681640118a4890b3da0d106eae8af7 # test1 uuid
 tmpfile=$(mktemp ./leaseXXXXXX)
 start=$(date +%Y-%m-%d)
 end=$(date -d "+5 days" +%Y-%m-%d)
+resource_type="dummy_node"
 lessee='test1-subproject'
 
 # Setup script, contains offer create test
 
-./setup.sh "$tmpfile" "$project_id" "$start" "$end" "$lessee"
+./setup.sh "$tmpfile" "$project_id" "$start" "$end" "$resource_type" "$lessee"
 
 # Sources variables defined in the setup script
 . $tmpfile
@@ -78,7 +79,7 @@ cat <<EOF
 Created lease $uuid:
   Starting at: $start_time
   Ending at:   $end_time
-  For: $resource_type $resource_uuid
+  For: $resource_type ${nodefile##/tmp/nodes/}
   From offer:  $test_offer_uuid
 EOF
 

--- a/tests/functional/test-no-lessee-id.sh
+++ b/tests/functional/test-no-lessee-id.sh
@@ -7,7 +7,7 @@ end=$(date -d "+5 days" +%Y-%m-%d)
 
 # Setup script, contains offer create test
 
-./setup.sh $tmpfile $project_id $start $end $resource_type
+./setup.sh $tmpfile $project_id $start $end
 
 . $tmpfile
 
@@ -28,7 +28,7 @@ openstack --os-cloud test1 esi offer create \
   $node_uuid \
   --start-time $start \
   --end-time $end \
-  --resource-type $resource_type \
+  --resource-type dummy_node \
   -f shell > $tmpfile 2> $errfile
 ec=$?
 expected_error="Time conflict for dummy_node $node_uuid."

--- a/tests/functional/test-no-lessee-id.sh
+++ b/tests/functional/test-no-lessee-id.sh
@@ -4,10 +4,11 @@ project_id=75681640118a4890b3da0d106eae8af7 # test1 uuid
 tmpfile=$(mktemp ./leaseXXXXXX)
 start=$(date +%Y-%m-%d)
 end=$(date -d "+5 days" +%Y-%m-%d)
+resource_type="dummy_node"
 
 # Setup script, contains offer create test
 
-./setup.sh $tmpfile $project_id $start $end
+./setup.sh "$tmpfile" "$project_id" "$start" "$end" "$resource_type"
 
 . $tmpfile
 
@@ -28,10 +29,10 @@ openstack --os-cloud test1 esi offer create \
   $node_uuid \
   --start-time $start \
   --end-time $end \
-  --resource-type dummy_node \
+  --resource-type $resource_type \
   -f shell > $tmpfile 2> $errfile
 ec=$?
-expected_error="Time conflict for dummy_node $node_uuid."
+expected_error="Time conflict for $resource_type $node_uuid."
 
 if ! cat $errfile | grep -q "$expected_error"; then
   if [[ $ec -eq 0 ]]; then

--- a/tests/functional/test-no-offer.sh
+++ b/tests/functional/test-no-offer.sh
@@ -6,7 +6,8 @@ start=$(date +%Y-%m-%d)
 end=$(date -d "+5 days" +%Y-%m-%d)
 nodefile=$(mktemp /tmp/nodes/XXXX)
 errfile=$(mktemp ./errXXXXXX)
-node_uuid=$(echo $nodefile | sed 's/\/tmp\/nodes\///')
+node_uuid=${nodefile##/tmp/nodes}
+resource_type="dummy_node"
 
 trap "rm -f $nodefile $tmpfile $errfile" EXIT
 
@@ -39,7 +40,7 @@ openstack --os-cloud test1 esi lease create \
   test1-subproject \
   --start-time $start \
   --end-time $end \
-  --resource-type dummy_node \
+  --resource-type $resource_type \
   -f shell > $tmpfile \
   || { ec=$?; echo "ERROR: failed to create lease" >&2; exit $ec; }
 
@@ -73,10 +74,10 @@ openstack --os-cloud test2 esi offer create \
   $node_uuid \
   --start-time $start \
   --end-time $end \
-  --resource-type dummy_node \
+  --resource-type $resource_type \
   -f shell > $tmpfile 2> $errfile
 ec=$?
-expected_error="Access was denied to dummy_node $node_uuid."
+expected_error="Access was denied to $resource_type $node_uuid."
 
 if ! cat $errfile | grep -q "$expected_error"; then
   if [[ $ec -eq 0 ]]; then
@@ -106,10 +107,10 @@ openstack --os-cloud test2 esi lease create \
   test2-subproject \
   --start-time $start \
   --end-time $end \
-  --resource-type dummy_node \
+  --resource-type $resource_type \
   -f shell > $tmpfile 2> $errfile
 ec=$?
-expected_error="Access was denied to dummy_node $node_uuid."
+expected_error="Access was denied to $resource_type $node_uuid."
 
 if ! cat $errfile | grep -q "$expected_error"; then
   if [[ $ec -eq 0 ]]; then

--- a/tests/functional/test-no-offer.sh
+++ b/tests/functional/test-no-offer.sh
@@ -76,7 +76,7 @@ openstack --os-cloud test2 esi offer create \
   --resource-type dummy_node \
   -f shell > $tmpfile 2> $errfile
 ec=$?
-expected_error="esi_leap:offer:offer_admin is disallowed by policy"
+expected_error="Access was denied to dummy_node $node_uuid."
 
 if ! cat $errfile | grep -q "$expected_error"; then
   if [[ $ec -eq 0 ]]; then
@@ -109,7 +109,7 @@ openstack --os-cloud test2 esi lease create \
   --resource-type dummy_node \
   -f shell > $tmpfile 2> $errfile
 ec=$?
-expected_error="esi_leap:offer:offer_admin is disallowed by policy"
+expected_error="Access was denied to dummy_node $node_uuid."
 
 if ! cat $errfile | grep -q "$expected_error"; then
   if [[ $ec -eq 0 ]]; then

--- a/tests/functional/test-offer-expire.sh
+++ b/tests/functional/test-offer-expire.sh
@@ -14,16 +14,17 @@ end=$(date -d "+1 minute" +"%Y-%m-%d %H:%M:%S")
 # The uuid variable will be overwritten, so we save it here
 test_offer_uuid=$uuid
 # Run cleanup if the script exits, contains offer delete test
+# Note: deletion will fail if handling of expired offers works
 trap "./cleanup.sh $test_offer_uuid; rm -f $tmpfile $errfile $nodefile" EXIT
-
-sleep 2m
-date +"%Y-%m-%D %H:%M:%S"
 
 ###################################
 ## OFFER LIST EXPIRED OFFER TEST ##
 ###################################
 
 echo "OFFER LIST EXPIRED OFFER TEST"
+
+sleep 2m
+date +"%Y-%m-%D %H:%M:%S"
 
 openstack --os-cloud test1-subproject esi offer list -f json > $tmpfile \
   || { ec=$?; echo "ERROR: failed to list offers" >&2; exit $ec; }

--- a/tests/functional/test-offer-expire.sh
+++ b/tests/functional/test-offer-expire.sh
@@ -4,6 +4,7 @@ project_id=75681640118a4890b3da0d106eae8af7 # test1 uuid
 tmpfile=$(mktemp ./leaseXXXXXX)
 start=$(date +%Y-%m-%d)
 end=$(date -d "+1 minute" +"%Y-%m-%d %H:%M:%S")
+resource_type="dummy_node"
 
 # Setup script, contains offer create test
 


### PR DESCRIPTION
https://github.com/CCI-MOC/esi-leap/pull/78 changed the error message displayed to the end user which broke some tests. Additionally, one test relied on a variable ("resource_type") to be set that was not set anywhere within the scripts, so it was removed and replaced with "dummy_node".