### PR TITLE
Clarified configuration requirements for VLANs

### DIFF
--- a/docs/source/install/external_network.rst
+++ b/docs/source/install/external_network.rst
@@ -21,6 +21,6 @@ The recommended way to allow external network access to a baremetal node is by `
               --dhcp \
               subnet-external
 
-Doing so allows ESI users to work with external networks the same way that they do with any other VLAN network. Note that all VLANs on the controller nodes should be configured to access the same NIC.
+Doing so allows ESI users to work with external networks the same way that they do with any other VLAN network.
 
 .. _creating a shared external provider network: https://docs.openstack.org/install-guide/launch-instance-networks-provider.html

--- a/docs/source/usage/network_scenarios.rst
+++ b/docs/source/usage/network_scenarios.rst
@@ -71,7 +71,7 @@ Floating IPs
 
 The use of floating IPs requires the following:
 
-* ESI's controllers must be configured to be able to access the private network's VLAN. This may require a lessee to submit a configuration request to an ESI administrator.
+* The private network's VLAN must be configured as a tagged network on the switch port for each controller.
 * An OpenStack router must be configured as described above.
 
 Once these requirements are in place, you can create a floating IP and associate it with a provisioned node's Neutron port (which can be found by running ``openstack esi node network list``):


### PR DESCRIPTION
It was mistakenly believed that user/external VLANs required network configuration on the controller itself; this change clairifies that all that is needed is controller switch port configuration.