### PR TITLE
Add documentation related to python-esiclient cluster commands

### DIFF
--- a/docs/source/usage/cli.rst
+++ b/docs/source/usage/cli.rst
@@ -348,7 +348,7 @@ Node/Network Management
 +-------------------------------+------------------------------------------------------------------------------------------------------+
 | Attach Network to Node        | ``openstack esi node network attach (--network <network> | --port <port> | --trunk <trunk>) <node>`` |
 +-------------------------------+------------------------------------------------------------------------------------------------------+
-| Detach Network from Node      | ``openstack esi node network detach --port <port> <node>``                                                  |
+| Detach Network from Node      | ``openstack esi node network detach --port <port> <node>``                                           |
 +-------------------------------+------------------------------------------------------------------------------------------------------+
 
 Boot Node from Volume

--- a/docs/source/usage/cluster.rst
+++ b/docs/source/usage/cluster.rst
@@ -1,0 +1,148 @@
+Installing a Cluster on ESI
+===========================
+
+A lessee wishing to create a cluster out of multiple leased nodes and a private network can do so by running the correct `CLI commands`_. Alternatively, they can use the cluster CLI commands in `python-esiclient`_ to simplify the workflow involved in creating and managing their clusters.
+
+Prerequisites
+-------------
+
+* `python-esiclient`_ must be installed
+* The nodes in the cluster must use image-based provisioning, with the image listed with ``openstack image list``
+
+Orchestrating the Cluster
+-------------------------
+
++---------------------+---------------------------------------------------------------------+
+|                     | **Actions**                                                         |
++---------------------+---------------------------------------------------------------------+
+| Orchestrate Cluster | ``openstack esi cluster orchestrate <path-to-cluster-config-file>`` |
++---------------------+---------------------------------------------------------------------+
+
+A single command is sufficient to provision a bare metal cluster and configure its networking.
+
+Cluster Configuration File
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A sample cluster configuration file is provided here:
+
+.. prompt::
+
+  {
+      "node_configs": [
+	  {
+	      "nodes": {
+		  "node_uuids": ["node1"]
+	      },
+	      "network": {
+		  "network_uuid": "private-network-1",
+		  "tagged_network_uuids": ["private-network-2"],
+		  "fip_network_uuid": "external"
+	      },
+	      "provisioning": {
+		  "provisioning_type": "image",
+		  "image_uuid": "image-name",
+		  "ssh_key": "/path/to/ssh/key"
+	      }
+	  },
+	  {
+	      "nodes": {
+		  "num_nodes": "2",
+		  "resource_class": "baremetal"
+	      },
+	      "network": {
+		  "network_uuid": "private-network-1"
+	      },
+	      "provisioning": {
+		  "provisioning_type": "image",
+		  "image_uuid": "image-name-2",
+		  "ssh_key": "/path/to/ssh/key"
+	      }
+	  }
+      ]
+  }
+
+The config file consists of one or more ``node_configs`` sections, each of which contains the following:
+
+nodes
+^^^^^
+
+The ``nodes`` section identifies which nodes will be used. You can either specifiy specific nodes by name or UUID:
+
+.. prompt::
+
+  "nodes": {
+     "node_uuids": ["node1"]
+  }
+
+Or look for a given number of nodes of a specific resource class:
+
+.. prompt::
+
+  "nodes": {
+     "num_nodes": 2,
+     "resource_class": "baremetal"
+  }
+
+If the requested nodes cannot be found, the orchestration command will throw an error.
+
+network
+^^^^^^^
+
+The ``network`` section details how nodes will be networked. Only the ``network_uuid`` attribute is required.
+
+.. prompt::
+
+  "network": {
+     "network_uuid": "private-network-1"
+  }
+
+There are two optional attributes that can be specified. ``tagged_network_uuids`` creates a trunk port with the network specified in ``network_uuid`` and the networks specified in ``tagged_network_uuids``; and ``fip_network_uuid`` creates a floating IP on the specified network attached to the node. 
+
+.. prompt::
+
+  "network": {
+     "network_uuid": "private-network-1"
+     "tagged_network_uuids": ["private-network-2"],
+     "fip_network_uuid": "external"
+  }
+
+provisioning
+^^^^^^^^^^^^
+
+The ``provisioning`` section details how nodes will be provisioned. Currently only image-based provisioning is supported; all the listed attributes are required.
+
+.. prompt::
+
+  "provisioning": {
+     "provisioning_type": "image",
+     "image_uuid": "image-name",
+     "ssh_key": "/path/to/ssh/key"
+  }
+
+Listing Clusters
+----------------
+
++---------------+--------------------------------+
+|               | **Actions**                    |
++---------------+--------------------------------+
+| List Clusters | ``openstack esi cluster list`` |
++---------------+--------------------------------+
+
+This command lists all your clusters, along with each cluster's associated nodes and each node's associated resources (ports, floating IPs, etc).
+
+Undeploying a Cluster
+---------------------
+
++------------------+---------------------------------------------------+
+|                  | **Actions**                                       |
++------------------+---------------------------------------------------+
+| Undeploy Cluster | ``openstack esi cluster undeploy <cluster-uuid>`` |
++------------------+---------------------------------------------------+
+
+This command undeploys a cluster by undeploying all nodes and deleting all associated resources. Cluster UUIDs can be found by running ``openstack esi cluster list``.
+
+Using this command is highly recommended, as it ensures resources are freed up so they no longer count against your quota.
+
+
+.. _CLI commands: cli.html
+.. _python-esiclient: https://github.com/CCI-MOC/python-esiclient

--- a/docs/source/usage/index.rst
+++ b/docs/source/usage/index.rst
@@ -41,6 +41,7 @@ General Information
    new_user_guide
    lease_management
    network_scenarios
+   cluster
    openshift
    keylime
    cli

--- a/docs/source/usage/new_user_guide.rst
+++ b/docs/source/usage/new_user_guide.rst
@@ -57,7 +57,10 @@ Your ESI installation may have networks available for use. However you may also 
 Configuring and Deploying Your Nodes
 ------------------------------------
 
-A node in the **available** state can be configured and deployed. There are multiple options for doing so, some of which are detailed in the `documentation for provisioning a node`_.
+A node in the **available** state can be configured and deployed. There are multiple options for doing so:
+
+* To provision individual nodes, use the instructions detailed in `documentation for provisioning a node`_.
+* To provision a cluster all at once, use the instructions detailed in `documentation for provisioning a cluster`_.
 
 Accessing Your Nodes
 --------------------
@@ -90,6 +93,7 @@ If you have suggestions for improving this guide, please `contact us`_!
 
 .. _documentation regarding private networks: network_scenarios.html#private-networks
 .. _documentation for provisioning a node: cli.html#provisioning-a-node
+.. _documentation for provisioning a cluster: cluster.html
 .. _detailed in the ESI documentation: index.html#general-information
 .. _OpenStack Ironic documentation: https://docs.openstack.org/ironic/latest/
 .. _network scenarios documentation: network_scenarios.html

--- a/docs/source/usage/openshift.rst
+++ b/docs/source/usage/openshift.rst
@@ -7,12 +7,15 @@ Installing OpenShift on ESI
 
 Owners and lessees can easily install OpenShift on hardware managed through ESI through the use of the `OpenShift Assisted Installer`_. This guide assumes that the relevant roles have been granted access to the required Ironic actions.
 
+There are two methods of using the Assisted Installer to install OpenShift: through the web UI, and through a CLI using `python-esiclient`_. Both methods have the same initial prerequisites.
+
 Prerequisites
 -------------
 
 * Access to the OpenShift Assisted Installer
    * You may use https://console.redhat.com or a local installation of the OpenShift Assisted Installer
 * `Access to an external network`_.
+* A `private network`_ with an `OpenStack router`_ for external network access and floating IP capabilities and a `private DNS server`_ for your private network
 * Usage of ESI-managed nodes in the 'available' state
 
 The Ironic provisioning network must also be able to reach the Assisted Installer. If using https://console.redhat.com, an ESI administrator can configure this access with an external network and an OpenStack router:
@@ -23,17 +26,11 @@ The Ironic provisioning network must also be able to reach the Assisted Installe
     openstack router set --external-gateway <external network> provisioning-router
     openstack router add subnet external-router <provisioning subnet>
 
-Create a Private Network
-------------------------
-
-Start by `creating a private network`_. In addition, do the following
-
-* `Create an OpenStack router`_ for external network access and floating IP capabilities
-* `Configure a private DNS server`_ for your private network
-
+Using the Assisted Installer Web UI
+-----------------------------------
 
 Prepare Cluster on Assisted Installer
--------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Log onto the Assisted Installer and select 'OpenShift' from the menu
 * Click on 'Create Cluster', select the 'Datacenter' tab, and create a cluster from the 'Assisted Installer' subsection
@@ -45,7 +42,7 @@ Prepare Cluster on Assisted Installer
    * Click 'Generate Discovery ISO' and record the Discovery ISO URL
 
 Configure Ironic Nodes
-----------------------
+~~~~~~~~~~~~~~~~~~~~~~
 
 * Run these commands to configure your nodes to boot from the generated OpenShift ISO:
 
@@ -62,7 +59,7 @@ Configure Ironic Nodes
 
 
 Deploy
-------
+~~~~~~
 
 * Once your nodes are ready, run the deploy command:
 
@@ -85,7 +82,7 @@ Deploy
 * Installation will begin and eventually complete. Once it does, the Assisted Installer will have credentials for logging into your OpenShift console.
 
 Post Install
-------------
+~~~~~~~~~~~~
 
 * Allow external access to your API IP and Ingress IP as follows:
 
@@ -109,7 +106,7 @@ Post Install
 * Configure private DNS as required using the internal IPs.
 
 Add Hosts
----------
+~~~~~~~~~
 
 * Log onto the Assisted Installer, select 'Clusters', and click on your cluster.
 * Navigate to the 'Add Hosts' tab.
@@ -150,14 +147,77 @@ Add Hosts
    * Click on their statuses to approve their CSRs.
 
 Remove Hosts
-------------
+~~~~~~~~~~~~
 
 * Follow the Openshift documentation for `deleting nodes from a cluster`_.
 * For each node that was removed, run `openstack baremetal node undeploy <node>`
 
+Using the python-esiclient CLI
+------------------------------
+
+Configure Access to the Assisted Installer API
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The python-esiclient CLI commands requires the user to access the Assisted Installer API. In order to do so, the user must `follow the steps in the Assisted Installer API documentation`_ which detail how to create a ``refresh-token`` script and how to export a ``PULL_SECRET`` to your environment.
+
+Create a Cluster Configuration File
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A cluster configuration file contains the following:
+
+.. prompt::
+
+  {
+      "cluster_name": "name-of-cluster",
+      "openshift_version": "4.13.12",
+      "high_availability_mode": "Full",
+      "base_dns_domain": "your.dns",
+      "api_vip": "aaa.aa.aa.aaa",                  // a free IP on your private subnet
+      "ingress_vip": "bbb.bb.bb.bbb",              // a free IP on your private subnet
+      "ssh_public_key": "public-key",              // the content of the public key file (not just the path to the key)
+      "external_network_name": "external",
+      "private_network_name": "private-network",
+      "private_subnet_name": "private-subnet",
+      "nodes": ["node1", "node2", "node3"]
+  }
+
+Orchestrate the Cluster
+~~~~~~~~~~~~~~~~~~~~~~~
+
++---------------------+-----------------------------------------------------------------------+
+|                     | **Actions**                                                           |
++---------------------+-----------------------------------------------------------------------+
+| Orchestrate Cluster | ``openstack esi openshift orchestrate <path-to-cluster-config-file>`` |
++---------------------+-----------------------------------------------------------------------+
+
+Once the cluster config file is created, run ``refresh-token`` and then ``openstack esi openshift orchestrate`` to start the orchestration of the OpenShift cluster.
+
+Installation will take roughly an hour, and involves constant calls to the Assisted Installer API. However, the token from ``refresh-token`` will expire after 15 minutes. When this happens, the orchestration command will fail. Fortunately, it will do so while providing a command to continue installation:
+
+.. prompt::
+
+  * YOU MAY NEED TO REFRESH YOUR OPENSHIFT API TOKEN
+  Run this command to continue installation:
+  openstack esi orchestrate openshift --cluster-id the-generated-cluster-id --infra-env-id the-generated-infra-env-id
+
+If you see this message, simply run ``refresh-token`` again and then copy and paste the specified command.
+
+Undeploy the Cluster
+~~~~~~~~~~~~~~~~~~~~
+
++------------------+--------------------------------------------------------------------+
+|                  | **Actions**                                                        |
++------------------+--------------------------------------------------------------------+
+| Undeploy Cluster | ``openstack esi openshift undeploy <path-to-cluster-config-file>`` |
++------------------+--------------------------------------------------------------------+
+
+To undeploy the OpenShift cluster, run the above command while passing in the same cluster configuration file used to orchestrate it. This ensures that any associated resources will be removed, freeing up quota.
+
 .. _Access to an external network: https://esi.readthedocs.io/en/latest/install/external_network.html
-.. _creating a private network: https://esi.readthedocs.io/en/latest/usage/network_scenarios.html#private-networks
-.. _Create an OpenStack router: https://esi.readthedocs.io/en/latest/usage/network_scenarios.html#routers
-.. _Configure a private DNS server: https://esi.readthedocs.io/en/latest/usage/network_scenarios.html#private-dns
+.. _private network: https://esi.readthedocs.io/en/latest/usage/network_scenarios.html#private-networks
+.. _OpenStack router: https://esi.readthedocs.io/en/latest/usage/network_scenarios.html#routers
+.. _private DNS server: https://esi.readthedocs.io/en/latest/usage/network_scenarios.html#private-dns
 .. _OpenShift Assisted Installer: https://cloud.redhat.com/blog/using-the-openshift-assisted-installer-service-to-deploy-an-openshift-cluster-on-metal-and-vsphere
 .. _deleting nodes from a cluster: https://docs.openshift.com/container-platform/4.11/nodes/nodes/nodes-nodes-working.html#deleting-nodes
+.. _python-esiclient: https://github.com/CCI-MOC/python-esiclient
+.. _follow the steps in the Assisted Installer API documentation: https://access.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform/2023/html/assisted_installer_for_openshift_container_platform/installing-with-api


### PR DESCRIPTION
This documentation adds a cluster provisioning section, and updates the OpenShift section with information regarding how to use python-esiclient for orchestration.