### PR TITLE
Explicitly set mtu to 1500 when creating networks

### DIFF
--- a/docs/source/install/external_network.rst
+++ b/docs/source/install/external_network.rst
@@ -9,7 +9,7 @@ The recommended way to allow external network access to a baremetal node is by `
               --provider-network-type vlan \
               --provider-segment <vlan id> \
               --provider-physical-network datacentre \
-              --external --share \
+              --external --share --mtu 1500 \
               external
     openstack subnet create \
               --network external \

--- a/docs/source/usage/network_scenarios.rst
+++ b/docs/source/usage/network_scenarios.rst
@@ -12,7 +12,7 @@ If a lessee wishes to use a private network, they can run the following commands
 
   .. prompt:: bash $
 
-    openstack network create <network name>
+    openstack network create --mtu 1500 <network name>
     openstack subnet create --subnet-range <subnet range> --allocation-pool start=<allocation start>,end=<allocation end> --network <network name> <subnet name>
 
 The created network will automatically have an assigned VLAN. This network can then be attached to a node as follows:


### PR DESCRIPTION
The recommended mtu for networks is 1500; however, if the max mtu is higher, neutron will default the mtu to the max value. This change updates the documentation so that network creation examples set the mtu to 1500.